### PR TITLE
[HOTFIX] Bottom tabs logic - Profile data - Modal position

### DIFF
--- a/app.json
+++ b/app.json
@@ -40,9 +40,7 @@
         "origin": false
       },
       "eas": {
-        "projectId": "12c2e3e8-0053-44e5-bcc8-2f5d5032ff0e"
       }
-    },
-    "owner": "fabrizioserial"
+    }
   }
 }

--- a/src/app/(auth)/(tabs)/_layout.tsx
+++ b/src/app/(auth)/(tabs)/_layout.tsx
@@ -55,7 +55,9 @@ const TabsLayout = () => {
                 focused={focused}
                 icon={iconName}
                 onPress={
-                  needsIntroduction === aboutMe?.hasCompletedIntroduction ? undefined : handlePress
+                  needsIntroduction && needsIntroduction === !aboutMe?.hasCompletedIntroduction
+                    ? handlePress
+                    : undefined
                 }
               />
             ),

--- a/src/app/(auth)/(tabs)/profile/index.tsx
+++ b/src/app/(auth)/(tabs)/profile/index.tsx
@@ -57,12 +57,16 @@ export default function Page() {
               <StyledText css={{ color: theme.gray100 }} variant="h3">
                 {profile?.name} {profile?.lastname}
               </StyledText>
-              <StyledText css={{ color: theme.gray100 }} variant="body2">
-                {profile?.career}
-              </StyledText>
-              <StyledText css={{ color: theme.gray100 }} variant="body2">
-                {profile?.profession}
-              </StyledText>
+              {profile?.career && (
+                <StyledText css={{ color: theme.gray100 }} variant="body2">
+                  {profile?.career}
+                </StyledText>
+              )}
+              {profile?.profession && (
+                <StyledText css={{ color: theme.gray100 }} variant="body2">
+                  {profile?.profession}
+                </StyledText>
+              )}
               <StyledText css={{ color: theme.gray100 }} variant="body2">
                 {profile?.city}
               </StyledText>

--- a/src/components/tab/TabItem/index.tsx
+++ b/src/components/tab/TabItem/index.tsx
@@ -13,8 +13,20 @@ interface TabItemProps {
 const TabItem = ({ focused, name, icon: Icon, onPress }: TabItemProps) => {
   const theme = useTheme();
 
-  const TextWithIcon = (
-    <>
+  const WrapperComponent = onPress ? Pressable : View;
+
+  return (
+    <WrapperComponent
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: 4,
+        height: 50,
+        width: 60,
+      }}
+      onPress={onPress}
+    >
       <Icon color={focused ? theme.gray100 : theme.primary600} size={32} />
       <StyledText
         variant={'body3'}
@@ -25,21 +37,7 @@ const TabItem = ({ focused, name, icon: Icon, onPress }: TabItemProps) => {
       >
         {name}
       </StyledText>
-    </>
-  );
-  return (
-    <View
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        gap: 4,
-        height: 50,
-        width: 60,
-      }}
-    >
-      {onPress ? <Pressable onPress={onPress}>{TextWithIcon}</Pressable> : TextWithIcon}
-    </View>
+    </WrapperComponent>
   );
 };
 

--- a/src/hoc/modals/IntroModal/index.tsx
+++ b/src/hoc/modals/IntroModal/index.tsx
@@ -23,64 +23,65 @@ const IntroModal = ({ handleOnClose }: IntroModalProps) => {
   };
   return (
     <Modal animationType="slide" transparent={true} visible={open} onRequestClose={handleOnClose}>
-      <StyledColumn
-        css={{
-          width: 342,
-          alignItems: 'center',
-          paddingHorizontal: 24,
-          paddingTop: 32,
-          paddingBottom: 24,
-          gap: 16,
-          backgroundColor: theme.primary700,
-          position: 'absolute',
-          top: 250,
-          left: 24,
-          borderRadius: 8,
-          border: 1,
-          borderStyle: 'solid',
-          borderColor: theme.primary650,
-        }}
-      >
-        <StyledColumn css={{ gap: 8, alignItems: 'center' }}>
+      <StyledColumn style={{ justifyContent: 'center', alignItems: 'center' }}>
+        <StyledColumn
+          css={{
+            width: 342,
+            alginItems: 'center',
+            paddingHorizontal: 24,
+            paddingTop: 32,
+            paddingBottom: 24,
+            gap: 16,
+            backgroundColor: theme.primary700,
+            position: 'absolute',
+            top: 250,
+            borderRadius: 8,
+            border: 1,
+            borderStyle: 'solid',
+            borderColor: theme.primary650,
+          }}
+        >
           <StyledColumn css={{ gap: 8, alignItems: 'center' }}>
-            <StyledText
-              variant="h1"
-              css={{
-                textAlign: 'center',
-                color: theme.gray100,
-              }}
-            >
-              Ya casi! &#x1F64C;&#x1F3FB;
-            </StyledText>
-            <StyledText variant="body1" css={{ color: theme.gray100 }}>
-              Para acceder al contenido, es necesario que completes la{' '}
-              <StyledText css={{ fontFamily: 'Roboto-Bold', color: theme.gray100 }}>
-                introducción{' '}
+            <StyledColumn css={{ gap: 8, alignItems: 'center' }}>
+              <StyledText
+                variant="h1"
+                css={{
+                  textAlign: 'center',
+                  color: theme.gray100,
+                }}
+              >
+                Ya casi! &#x1F64C;&#x1F3FB;
               </StyledText>
-              primero.
-            </StyledText>
+              <StyledText variant="body1" css={{ color: theme.gray100 }}>
+                Para acceder al contenido, es necesario que completes la{' '}
+                <StyledText css={{ fontFamily: 'Roboto-Bold', color: theme.gray100 }}>
+                  introducción{' '}
+                </StyledText>
+                primero.
+              </StyledText>
+            </StyledColumn>
           </StyledColumn>
-        </StyledColumn>
 
-        <Button
-          onPress={handleGoToIntroduction}
-          variant={'primary'}
-          css={{
-            width: '100%',
-            backgroundColor: theme.primary400,
-          }}
-        >
-          Ir a la introducción
-        </Button>
-        <Button
-          onPress={handleOnClose}
-          variant="ghost"
-          css={{
-            width: '100%',
-          }}
-        >
-          Más tarde
-        </Button>
+          <Button
+            onPress={handleGoToIntroduction}
+            variant={'primary'}
+            css={{
+              width: '100%',
+              backgroundColor: theme.primary400,
+            }}
+          >
+            Ir a la introducción
+          </Button>
+          <Button
+            onPress={handleOnClose}
+            variant="ghost"
+            css={{
+              width: '100%',
+            }}
+          >
+            Más tarde
+          </Button>
+        </StyledColumn>
       </StyledColumn>
     </Modal>
   );


### PR DESCRIPTION
Fixed bottom tabs bug that made pressing a locked item possible.
Fixed a bottom tabs bug that wouldn't let you press explore after finishing introduction pill. 
Fixed a Profile screen bug that rendered an empty text when there was nothing on that prop. 
Fixed a Modal bug to center the modal. 
