### PR TITLE
[LER-BUG-10-NOTION] Questionnaire not showing read only version

### DIFF
--- a/src/app/(auth)/pill/questionnaire/[questionnaireId]/index.tsx
+++ b/src/app/(auth)/pill/questionnaire/[questionnaireId]/index.tsx
@@ -10,7 +10,7 @@ import {
   Platform,
   VirtualizedList,
 } from 'react-native';
-import { useLDispatch, useLSelector } from '../../../../../redux/hooks';
+import { useLSelector } from '../../../../../redux/hooks';
 import { useQuestionnaireByIdQuery } from '../../../../../redux/service/questionnaire.service';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import usePrevious from '../../../../../hooks/usePrevious';
@@ -28,6 +28,7 @@ const Questionnaire = () => {
       skip: !questionnaireId,
     },
   );
+
   const blocksIds = useLSelector((state) => state.questionnaire.blocksIds);
   const pillProgress = useLSelector(
     (state) => state.questionnaire?.questionnaire?.questionnaire.progress,
@@ -67,7 +68,9 @@ const Questionnaire = () => {
       prevData !== undefined &&
       [QuestionnaireState.COMPLETED, QuestionnaireState.FAILED].includes(pillCompleted)
     ) {
-      setTimeout(() => animateBoxes(), 850);
+      setTimeout(() => {
+        animateBoxes();
+      }, 850);
     }
   }, [pillCompleted, prevData]);
 

--- a/src/components/bubbles/QuestionnaireImgAnswer/index.tsx
+++ b/src/components/bubbles/QuestionnaireImgAnswer/index.tsx
@@ -30,7 +30,7 @@ const QuestionnaireImgAnswer = ({ blockId, nextBlockId }: QuestionnaireImgAnswer
   const last = useLSelector((state) => state.questionnaire.last);
   const sealed = block.sealed || !(last === block.id);
 
-  const correctAnswerId = block.correctAnswer?.[0] ?? '';
+  const correctValue = block.correctValue?.[0] ?? '';
   const isImgSelectedCorrect = values.value === block.correctAnswer?.[0];
 
   const handleSelect = (answerId: string) => {
@@ -45,9 +45,9 @@ const QuestionnaireImgAnswer = ({ blockId, nextBlockId }: QuestionnaireImgAnswer
     }));
   };
 
-  const renderStatusIcon = (id: string, selected: boolean) => {
+  const renderStatusIcon = (image: string, selected: boolean) => {
     if (selected && sealed) {
-      const isCorrect = correctAnswerId === id;
+      const isCorrect = correctValue === image;
       return isCorrect ? <CheckIcon /> : <MultiplyIcon />;
     }
     return null;
@@ -88,7 +88,7 @@ const QuestionnaireImgAnswer = ({ blockId, nextBlockId }: QuestionnaireImgAnswer
                 />
                 {renderStatusIcon(item.image, !!item?.selected)}
               </StyledRow>
-              {sealed && item.selected && <PointsDisplay points={block.points ?? 0} />}
+              {sealed && item.selected && <PointsDisplay points={block.pointsAwarded ?? 0} />}
             </StyledColumn>
           );
         })}

--- a/src/components/bubbles/QuestionnaireImgAnswer/index.tsx
+++ b/src/components/bubbles/QuestionnaireImgAnswer/index.tsx
@@ -30,7 +30,7 @@ const QuestionnaireImgAnswer = ({ blockId, nextBlockId }: QuestionnaireImgAnswer
   const last = useLSelector((state) => state.questionnaire.last);
   const sealed = block.sealed || !(last === block.id);
 
-  const correctValue = block.correctValue?.[0] ?? '';
+  const correctValue = block.correctAnswer?.[0] ?? '';
   const isImgSelectedCorrect = values.value === block.correctAnswer?.[0];
 
   const handleSelect = (answerId: string) => {
@@ -46,7 +46,7 @@ const QuestionnaireImgAnswer = ({ blockId, nextBlockId }: QuestionnaireImgAnswer
   };
 
   const renderStatusIcon = (image: string, selected: boolean) => {
-    if (selected && sealed) {
+    if (selected && sealed && block?.correctAnswer) {
       const isCorrect = correctValue === image;
       return isCorrect ? <CheckIcon /> : <MultiplyIcon />;
     }

--- a/src/components/pill/QuestionnaireRender/QuestionnaireBubbleToRender/index.tsx
+++ b/src/components/pill/QuestionnaireRender/QuestionnaireBubbleToRender/index.tsx
@@ -24,14 +24,8 @@ const QuestionnaireBubbleToRender = ({
   nextBlockId,
   last,
 }: QuestionnaireBubbleToRenderProps) => {
-  const {
-    block,
-    handleSingleAnswer,
-    handleMultipleAnswer,
-    handleSealedMultipleAnswer,
-    // handleImageSelection,
-    // handleSealedImageSelection,
-  } = useQuestionnaire(blockId, { nextBlockId });
+  const { block, handleSingleAnswer, handleMultipleAnswer, handleSealedMultipleAnswer } =
+    useQuestionnaire(blockId, { nextBlockId });
 
   switch (block.type) {
     case 'text':
@@ -61,7 +55,7 @@ const QuestionnaireBubbleToRender = ({
           correctAnswers={block.correctAnswer}
           points={block?.pointsAwarded ?? 0}
           onChange={handleMultipleAnswer}
-          sealed={!(last === block.id)}
+          sealed={block.sealed || !(last === block.id)}
         />
       );
     case 'single-choice':
@@ -71,7 +65,7 @@ const QuestionnaireBubbleToRender = ({
           options={block.options}
           onChange={(id) => handleSingleAnswer(id)}
           correctAnswers={block.correctAnswer}
-          sealed={!(last === block.id)}
+          sealed={block.sealed || !(last === block.id)}
           points={block?.pointsAwarded ?? 0}
           isSingleAnswer
         />

--- a/src/hooks/useQuestionnaire.tsx
+++ b/src/hooks/useQuestionnaire.tsx
@@ -7,7 +7,7 @@ import {
 } from '../redux/slice/questionnaire.slice';
 import { useAnswerQuestionnaireMutation } from '../redux/service/questionnaire.service';
 import { useLocalSearchParams } from 'expo-router';
-import { setCarousel } from '../redux/slice/pill.slice';
+import { setCarousel } from '../redux/slice/questionnaire.slice';
 
 interface useVirtualizedPillArgs {
   nextBlockId?: string;

--- a/src/redux/service/questionnaire.service.ts
+++ b/src/redux/service/questionnaire.service.ts
@@ -1,16 +1,11 @@
 import { api } from './api';
-import {
-  QuestionnaireBody,
-  QuestionnaireResponse,
-  QuestionnaireState,
-} from './types/questionnaire.response';
+import { QuestionnaireBody, QuestionnaireResponse } from './types/questionnaire.response';
 
 export const questionnaireApi = api.injectEndpoints({
   endpoints: (builder) => ({
     questionnaireById: builder.query<QuestionnaireResponse, { id: string }>({
       query: ({ id }) => ({
         url: `/api/questionnaire/${id}`,
-
         method: 'GET',
       }),
     }),

--- a/src/redux/slice/pill.slice.ts
+++ b/src/redux/slice/pill.slice.ts
@@ -26,6 +26,7 @@ export const StudentBubble = ['single-choice', 'multiple-choice', 'carousel'];
 export interface SingleChoiceBlockType extends CommonBlockType {
   type: 'single-choice';
   content?: string[];
+  sealed?: boolean;
   options: {
     id: string;
     text: string;

--- a/src/redux/slice/questionnaire.slice.ts
+++ b/src/redux/slice/questionnaire.slice.ts
@@ -1,5 +1,10 @@
 import { createSelector, createSlice } from '@reduxjs/toolkit';
-import { BlockType, MultipleChoiceBlockType, SingleChoiceBlockType } from './pill.slice';
+import {
+  BlockType,
+  CarouselBlockType,
+  MultipleChoiceBlockType,
+  SingleChoiceBlockType,
+} from './pill.slice';
 import { transformQuestionnaireResponseBlock } from './utils';
 import { RootState } from '../store';
 import { questionnaireApi } from '../service/questionnaire.service';
@@ -85,6 +90,26 @@ export const questionnaireSlice = createSlice({
         };
       }
     },
+    setCarousel: (state, action) => {
+      const { carouselBlockDetails }: Record<string, CarouselBlockType> = action.payload;
+      const id = carouselBlockDetails.id;
+      const block: CarouselBlockType = state.mapBlocks[id] as CarouselBlockType;
+
+      state.mapBlocks[id] = {
+        ...block,
+        imgOptions: carouselBlockDetails.imgOptions?.map((item) => {
+          if (!item.selected) {
+            return {
+              ...item,
+              selected: false,
+            };
+          } else {
+            return item;
+          }
+        }),
+        sealed: true,
+      };
+    },
   },
   extraReducers: (builder) => {
     builder
@@ -128,7 +153,7 @@ export const questionnaireSlice = createSlice({
 
           // Set properties to the answered bubble
           let lastBlock = state.mapBlocks[lastQuestionId];
-          if (['single-choice', 'multiple-choice'].includes(lastBlock.type)) {
+          if (['single-choice', 'multiple-choice', 'carousel'].includes(lastBlock.type)) {
             lastBlock = {
               ...lastBlock,
               pointsAwarded: action.payload.questionnaire.pointsAwarded,
@@ -158,7 +183,7 @@ export const getQuestionnaireTypeByID = createSelector(
   },
 );
 
-export const { setSingleAnswer, handleMultipleAnswerChange, sendMultipleAnswer } =
+export const { setSingleAnswer, handleMultipleAnswerChange, sendMultipleAnswer, setCarousel } =
   questionnaireSlice.actions;
 
 export default questionnaireSlice.reducer;

--- a/src/redux/slice/questionnaire.slice.ts
+++ b/src/redux/slice/questionnaire.slice.ts
@@ -97,6 +97,14 @@ export const questionnaireSlice = createSlice({
           action.payload.questionnaire.bubbles[action.payload.questionnaire.bubbles.length - 1].id;
         state.questionnaire = action.payload;
       })
+      .addMatcher(questionnaireApi.endpoints.answerQuestionnaire.matchPending, (state, action) => {
+        const lastQuestionId = state.last as string;
+        const lastBlock = state.mapBlocks[lastQuestionId];
+        state.mapBlocks[lastQuestionId] = {
+          ...lastBlock,
+          sealed: true,
+        };
+      })
       .addMatcher(
         questionnaireApi.endpoints.answerQuestionnaire.matchFulfilled,
         (state, action) => {


### PR DESCRIPTION
On this PR:
.- There was a bug on questionnaire carousel not showing read only mode, now it displays correctly and show correct icon when answer is right or wrong, also points are added now. 

To test this: 
.- Run the backend on this branch: feat/update-seed-program.

To take into account: 
.- There is a bug, probably a backend bug, if you answer the questionnaire wrong on multiple and single choice, the questionnaire shows the failure modal. Then, if you reload the app and go back again to the questionnaire, it will render new pills. This is a bug because is already failed, it shouldn't bring any new bubbles, even the status of the questionnaire on questionnaireById endpoint is 'inProgress' instead of "Failed".