### PR TITLE
[LER-114] Questionnaire time to unlock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "react-native-screens": "~3.22.0",
         "react-native-svg": "14.1.0",
         "react-redux": "^9.0.4",
+        "react-timer-hook": "^3.0.7",
         "redux-persist": "^6.0.0",
         "styled-components": "^6.1.4",
         "yup": "^1.3.3"
@@ -14566,6 +14567,14 @@
       },
       "peerDependencies": {
         "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-timer-hook": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/react-timer-hook/-/react-timer-hook-3.0.7.tgz",
+      "integrity": "sha512-ATpNcU+PQRxxfNBPVqce2+REtjGAlwmfoNQfcEBMZFxPj0r3GYdKhyPHdStvqrejejEi0QvqaJZjy2lBlFvAsA==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/readable-stream": {

--- a/package.json
+++ b/package.json
@@ -39,14 +39,15 @@
     "react-native-gesture-handler": "~2.12.0",
     "react-native-image-zoom-viewer": "^3.0.1",
     "react-native-progress": "^5.0.1",
+    "react-native-reanimated": "~3.3.0",
     "react-native-safe-area-context": "4.6.3",
     "react-native-screens": "~3.22.0",
     "react-native-svg": "14.1.0",
     "react-redux": "^9.0.4",
+    "react-timer-hook": "^3.0.7",
     "redux-persist": "^6.0.0",
     "styled-components": "^6.1.4",
-    "yup": "^1.3.3",
-    "react-native-reanimated": "~3.3.0"
+    "yup": "^1.3.3"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/src/app/(auth)/(tabs)/_layout.tsx
+++ b/src/app/(auth)/(tabs)/_layout.tsx
@@ -54,11 +54,11 @@ const TabsLayout = () => {
                 name={name}
                 focused={focused}
                 icon={iconName}
-                // onPress={
-                //   needsIntroduction && needsIntroduction === !aboutMe?.hasCompletedIntroduction
-                //     ? handlePress
-                //     : undefined
-                // }
+                onPress={
+                  needsIntroduction && needsIntroduction === !aboutMe?.hasCompletedIntroduction
+                    ? handlePress
+                    : undefined
+                }
               />
             ),
           }}

--- a/src/app/(auth)/(tabs)/explore/programDetail/components/PillsSection/index.tsx
+++ b/src/app/(auth)/(tabs)/explore/programDetail/components/PillsSection/index.tsx
@@ -5,7 +5,6 @@ import React from 'react';
 import { ProgramResponseType } from '../../../../../../../redux/service/types/program.response';
 import { useRouter } from 'expo-router';
 import { useLSelector } from '../../../../../../../redux/hooks';
-import { QuestionnaireState } from '../../../../../../../redux/service/types/questionnaire.response';
 
 interface PillsSectionProps {
   pills: ProgramResponseType['pills'];
@@ -15,15 +14,8 @@ interface PillsSectionProps {
 const PillsSection = ({ pills, questionnaire }: PillsSectionProps) => {
   const router = useRouter();
 
-  const questionnaireAnswerData = useLSelector(
-    (state) => state.questionnaire.questionnaire?.questionnaire,
-  );
   const questionnaireUnlockTime = useLSelector((state) => state.program.questionnaireUnlockTime);
-
-  const isQuestionnaireLocked =
-    questionnaire.isLocked ||
-    !!questionnaireUnlockTime ||
-    questionnaireAnswerData?.questionnaireState === QuestionnaireState.FAILED;
+  const isQuestionnaireLocked = !!questionnaireUnlockTime;
 
   const handleGoToPill = (id: string) =>
     router.push({
@@ -66,7 +58,7 @@ const PillsSection = ({ pills, questionnaire }: PillsSectionProps) => {
           pillNumber={0}
           duration={questionnaire.completionTimeMinutes}
           isLocked={isQuestionnaireLocked}
-          unlockTime={questionnaireAnswerData?.unlockTime}
+          unlockTime={questionnaireUnlockTime}
           id={questionnaire.id}
           isQuestionnaire
         />

--- a/src/app/(auth)/(tabs)/explore/programDetail/components/PillsSection/index.tsx
+++ b/src/app/(auth)/(tabs)/explore/programDetail/components/PillsSection/index.tsx
@@ -4,6 +4,8 @@ import PillRow from '../../../../../../../components/program/PillRow';
 import React from 'react';
 import { ProgramResponseType } from '../../../../../../../redux/service/types/program.response';
 import { useRouter } from 'expo-router';
+import { useLSelector } from '../../../../../../../redux/hooks';
+import { QuestionnaireState } from '../../../../../../../redux/service/types/questionnaire.response';
 
 interface PillsSectionProps {
   pills: ProgramResponseType['pills'];
@@ -13,6 +15,16 @@ interface PillsSectionProps {
 const PillsSection = ({ pills, questionnaire }: PillsSectionProps) => {
   const router = useRouter();
 
+  const questionnaireAnswerData = useLSelector(
+    (state) => state.questionnaire.questionnaire?.questionnaire,
+  );
+  const questionnaireUnlockTime = useLSelector((state) => state.program.questionnaireUnlockTime);
+
+  const isQuestionnaireLocked =
+    questionnaire.isLocked ||
+    !!questionnaireUnlockTime ||
+    questionnaireAnswerData?.questionnaireState === QuestionnaireState.FAILED;
+
   const handleGoToPill = (id: string) =>
     router.push({
       pathname: 'pill/mainPill',
@@ -21,10 +33,12 @@ const PillsSection = ({ pills, questionnaire }: PillsSectionProps) => {
       },
     });
 
-  const handleGoToQuestionnaire = (id: string) =>
+  const handleGoToQuestionnaire = (id: string) => {
+    if (isQuestionnaireLocked) return null;
     router.push({
       pathname: `pill/questionnaire/${id}`,
     });
+  };
 
   return (
     <StyledColumn css={{ gap: '8px', width: '100%', marginTop: '16px' }}>
@@ -51,7 +65,8 @@ const PillsSection = ({ pills, questionnaire }: PillsSectionProps) => {
           pillProgress={questionnaire.questionnaireProgress}
           pillNumber={0}
           duration={questionnaire.completionTimeMinutes}
-          isLocked={questionnaire.isLocked}
+          isLocked={isQuestionnaireLocked}
+          unlockTime={questionnaireAnswerData?.unlockTime}
           id={questionnaire.id}
           isQuestionnaire
         />

--- a/src/components/program/PillRow/index.tsx
+++ b/src/components/program/PillRow/index.tsx
@@ -15,6 +15,7 @@ interface PillRowInterface {
   pillName: string;
   duration: number;
   isLocked: boolean;
+  unlockTime?: string;
   id: string;
   isQuestionnaire?: boolean;
 }
@@ -25,6 +26,7 @@ const PillRow = ({
   pillName,
   duration,
   isLocked,
+  unlockTime,
   isQuestionnaire = false,
   id,
 }: PillRowInterface) => {

--- a/src/components/program/PillRow/index.tsx
+++ b/src/components/program/PillRow/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import * as Progress from 'react-native-progress';
 import { StyledRow, StyledText } from '../../styled/styles';
 import { useTheme } from 'styled-components';
@@ -36,10 +36,13 @@ const PillRow = ({
 
   const unlockQuestionnaireDispatch = () => dispatch(unlockQuestionnaire());
 
-  const { seconds, minutes, hours, isRunning } = useTimer({
+  const { seconds, minutes, hours, isRunning, restart } = useTimer({
     expiryTimestamp: unlockTime ? new Date(unlockTime) : new Date(),
     onExpire: () => isQuestionnaire && unlockQuestionnaireDispatch(),
   });
+  useEffect(() => {
+    if (unlockTime) restart(new Date(unlockTime));
+  }, [unlockTime]);
 
   return (
     <StyledRow

--- a/src/components/program/PillRow/index.tsx
+++ b/src/components/program/PillRow/index.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import * as Progress from 'react-native-progress';
-import { StyledBox, StyledRow, StyledText } from '../../styled/styles';
+import { StyledRow, StyledText } from '../../styled/styles';
 import { useTheme } from 'styled-components';
 import LockIcon from '../../../../assets/icons/LockIcon';
-import { Platform, Pressable } from 'react-native';
 import ChevronRightIcon from '../../../../assets/icons/ChevronRightIcon';
 import { EllipseIcon } from '../../../../assets/icons/EllipseIcon';
-import { useRouter } from 'expo-router';
 import QuestionnaireIcon from '../../../../assets/icons/QuestionnaireIcon';
+import { useTimer } from 'react-timer-hook';
+import { useLDispatch } from '../../../redux/hooks';
+import { unlockQuestionnaire } from '../../../redux/slice/program.slice';
 
 interface PillRowInterface {
   pillNumber: number;
@@ -31,7 +32,14 @@ const PillRow = ({
   id,
 }: PillRowInterface) => {
   const theme = useTheme();
-  const router = useRouter();
+  const dispatch = useLDispatch();
+
+  const unlockQuestionnaireDispatch = () => dispatch(unlockQuestionnaire());
+
+  const { seconds, minutes, hours, isRunning } = useTimer({
+    expiryTimestamp: unlockTime ? new Date(unlockTime) : new Date(),
+    onExpire: () => isQuestionnaire && unlockQuestionnaireDispatch(),
+  });
 
   return (
     <StyledRow
@@ -71,13 +79,23 @@ const PillRow = ({
           )}
         </StyledRow>
         <StyledRow css={{ alignItems: 'center', gap: 4, width: '75%' }}>
-          <StyledText variant="body2" color={!isLocked ? 'gray100' : 'gray600'}>
+          <StyledText
+            variant="body2"
+            color={!isLocked ? 'gray100' : 'gray600'}
+            css={{ width: isRunning ? '35%' : '' }}
+          >
             {pillName}
           </StyledText>
           <EllipseIcon size={4} color={!isLocked ? theme.gray100 : theme.gray500} />
           <StyledText variant="body3" color={!isLocked ? 'primary600' : 'gray600'}>
             {duration} min
           </StyledText>
+          {isRunning && (
+            <StyledText variant="body2" color={!isLocked ? 'gray100' : 'gray600'}>
+              Disponible en {hours < 10 ? `0${hours}` : hours}:
+              {minutes < 10 ? `0${minutes}` : minutes}:{seconds < 10 ? `0${seconds}` : seconds}hs
+            </StyledText>
+          )}
         </StyledRow>
       </StyledRow>
       {!isLocked && <ChevronRightIcon color={theme.primary600} />}

--- a/src/redux/service/types/program.response.ts
+++ b/src/redux/service/types/program.response.ts
@@ -30,6 +30,7 @@ export type ProgramResponseType = {
     completionTimeMinutes: number;
     questionnaireProgress: number;
     isLocked: boolean;
+    lockedUntil?: string;
   };
   leaderBoard: {
     up: {

--- a/src/redux/service/types/questionnaire.response.ts
+++ b/src/redux/service/types/questionnaire.response.ts
@@ -19,6 +19,7 @@ export type QuestionnaireResponse = {
     correct?: boolean;
     correctValue?: string[];
     pointsAwarded?: number;
+    unlockTime?: string;
     bubbles: BubbleResponseQuestionnaire[];
   };
   teacher: {

--- a/src/redux/slice/program.slice.ts
+++ b/src/redux/slice/program.slice.ts
@@ -25,6 +25,9 @@ export const programSlice = createSlice({
     setProgramId: (state, action) => {
       state.id = action.payload.id;
     },
+    unlockQuestionnaire: (state) => {
+      state.questionnaireUnlockTime = '';
+    },
   },
   extraReducers: (builder) => {
     builder
@@ -48,6 +51,6 @@ export const programSlice = createSlice({
   },
 });
 
-export const { setProgramId } = programSlice.actions;
+export const { setProgramId, unlockQuestionnaire } = programSlice.actions;
 
 export default programSlice.reducer;

--- a/src/redux/slice/program.slice.ts
+++ b/src/redux/slice/program.slice.ts
@@ -2,9 +2,11 @@ import { createSlice } from '@reduxjs/toolkit';
 import { ProgramsData } from '../service/types/program.response';
 import { programApi } from '../service/program.service';
 import { pillSlice } from './pill.slice';
+import { questionnaireApi } from '../service/questionnaire.service';
 
 interface initialStateType extends ProgramsData {
   id?: string;
+  questionnaireUnlockTime: string;
 }
 
 const initialState: initialStateType = {
@@ -13,6 +15,7 @@ const initialState: initialStateType = {
   programsInProgress: [],
   programsNotStarted: [],
   id: undefined,
+  questionnaireUnlockTime: '',
 };
 
 export const programSlice = createSlice({
@@ -32,7 +35,16 @@ export const programSlice = createSlice({
       })
       .addMatcher(programApi.endpoints.programById.matchFulfilled, (state, action) => {
         state.id = action.payload.id;
-      });
+        state.questionnaireUnlockTime = action.payload.questionnaire.lockedUntil ?? '';
+      })
+      .addMatcher(
+        questionnaireApi.endpoints.answerQuestionnaire.matchFulfilled,
+        (state, action) => {
+          if (action.payload.questionnaire?.unlockTime) {
+            state.questionnaireUnlockTime = action.payload.questionnaire?.unlockTime ?? '';
+          }
+        },
+      );
   },
 });
 


### PR DESCRIPTION
On this PR: 
.- Questionnaire locked when failed until time is finished.
.- New library installed (react-timer-hook), run the `npm install` command.

Extra:
.- Introduction modal working back again.

To test this: 
```
1. Go to program detail.
2. Do the questionnaire and fail it.
3. Go to program detail back again, you should see a countdown on the questionnaire, 
it is set to 10 minutes on the backend, when it reaches 0 it should let you do the questionnaire again.
```