### PR TITLE
[BUGFIX] Questionnaire is now correctly locked.

### DIFF
--- a/src/app/(auth)/(tabs)/explore/programDetail/components/PillsSection/index.tsx
+++ b/src/app/(auth)/(tabs)/explore/programDetail/components/PillsSection/index.tsx
@@ -15,7 +15,12 @@ const PillsSection = ({ pills, questionnaire }: PillsSectionProps) => {
   const router = useRouter();
 
   const questionnaireUnlockTime = useLSelector((state) => state.program.questionnaireUnlockTime);
-  const isQuestionnaireLocked = !!questionnaireUnlockTime;
+
+  const isQuestionnaireLocked = () => {
+    if (questionnaire.isLocked) return true;
+    if (questionnaireUnlockTime) return true;
+    return false;
+  };
 
   const handleGoToPill = (id: string) =>
     router.push({
@@ -26,7 +31,7 @@ const PillsSection = ({ pills, questionnaire }: PillsSectionProps) => {
     });
 
   const handleGoToQuestionnaire = (id: string) => {
-    if (isQuestionnaireLocked) return null;
+    if (isQuestionnaireLocked()) return null;
     router.push({
       pathname: `pill/questionnaire/${id}`,
     });
@@ -57,7 +62,7 @@ const PillsSection = ({ pills, questionnaire }: PillsSectionProps) => {
           pillProgress={questionnaire.questionnaireProgress}
           pillNumber={0}
           duration={questionnaire.completionTimeMinutes}
-          isLocked={isQuestionnaireLocked}
+          isLocked={isQuestionnaireLocked()}
           unlockTime={questionnaireUnlockTime}
           id={questionnaire.id}
           isQuestionnaire

--- a/src/components/program/PillRow/index.tsx
+++ b/src/components/program/PillRow/index.tsx
@@ -40,6 +40,7 @@ const PillRow = ({
     expiryTimestamp: unlockTime ? new Date(unlockTime) : new Date(),
     onExpire: () => isQuestionnaire && unlockQuestionnaireDispatch(),
   });
+
   useEffect(() => {
     if (unlockTime) restart(new Date(unlockTime));
   }, [unlockTime]);
@@ -85,7 +86,7 @@ const PillRow = ({
           <StyledText
             variant="body2"
             color={!isLocked ? 'gray100' : 'gray600'}
-            css={{ width: isRunning ? '35%' : '' }}
+            css={{ width: isRunning && !!unlockTime ? '35%' : '' }}
           >
             {pillName}
           </StyledText>
@@ -93,7 +94,7 @@ const PillRow = ({
           <StyledText variant="body3" color={!isLocked ? 'primary600' : 'gray600'}>
             {duration} min
           </StyledText>
-          {isRunning && (
+          {isRunning && !!unlockTime && (
             <StyledText variant="body2" color={!isLocked ? 'gray100' : 'gray600'}>
               Disponible en {hours < 10 ? `0${hours}` : hours}:
               {minutes < 10 ? `0${minutes}` : minutes}:{seconds < 10 ? `0${seconds}` : seconds}hs


### PR DESCRIPTION
On this PR:
.- This bugfix is for the questionnaire lock functionality, it was unlocked when pills were not finished.
.- This also corrects the available time label when questionnaire is available.